### PR TITLE
Add a format_duration() rendering util

### DIFF
--- a/autonomie_base/tests/utils/test_date.py
+++ b/autonomie_base/tests/utils/test_date.py
@@ -14,3 +14,9 @@ def test_str_to_date():
     assert date.str_to_date(None) == None
     assert date.str_to_date("12/11/14", formats=("%y/%m/%d",)) == \
         datetime.datetime(2012, 11, 14)
+
+
+def test_format_duration():
+    assert date.format_duration((12, 12)) == '12h12'
+    assert date.format_duration((12, 00)) == '12h'
+    assert date.format_duration((12, 00), short=False) == '12h00'

--- a/autonomie_base/utils/date.py
+++ b/autonomie_base/utils/date.py
@@ -109,3 +109,17 @@ def format_date(date, short=True):
         return format_short_date(date)
     else:
         return format_long_date(date)
+
+
+def format_duration(duration, short=True):
+    """
+    return a pretty print version of a duration.
+
+    :param (int,int) duration: hours,minutes tuple to convert.
+    :param bool short: if True, hide minutes part when it equals zero.
+    """
+    hours, minutes = duration
+    if minutes == 0 and short:
+        return '{}h'.format(hours)
+    else:
+        return '{}h{:02d}'.format(hours, minutes)

--- a/autonomie_base/utils/math.py
+++ b/autonomie_base/utils/math.py
@@ -43,7 +43,7 @@ def floor_to_precision(
 ):
     """
     floor a value in its int representation:
-        >>> floor_to_thousand(296999)
+        >>> floor_to_precision(296999)
         297000
 
         amounts are of the form : value * 10 ** dialect_precision it allows to


### PR DESCRIPTION
e.g: for use in workshop duration listing.